### PR TITLE
provided up navigation from action bar in local trader

### DIFF
--- a/public/mbw/src/main/AndroidManifest.xml
+++ b/public/mbw/src/main/AndroidManifest.xml
@@ -123,7 +123,14 @@
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
             android:windowSoftInputMode="stateAlwaysHidden" >
         </activity>
-        <activity android:name="com.mycelium.wallet.lt.activity.LtMainActivity"/>
+        <activity
+            android:name="com.mycelium.wallet.lt.activity.LtMainActivity"
+            android:parentActivityName="com.mycelium.wallet.activity.modern.ModernMain" >
+        	<!-- Parent activity to provide up navigation from home button, and meta-data to support 4.0 and lower -->
+        	<meta-data
+            	android:name="android.support.PARENT_ACTIVITY"
+            	android:value="com.mycelium.wallet.activity.modern.ModernMain" />
+        </activity>
         <activity android:name="com.mycelium.wallet.lt.activity.CreateTrader1Activity" />
         <activity android:name="com.mycelium.wallet.lt.activity.CreateTrader2Activity" />
         <activity android:name="com.mycelium.wallet.lt.activity.SolveCaptchaActivity" />

--- a/public/mbw/src/main/java/com/mycelium/wallet/lt/activity/LtMainActivity.java
+++ b/public/mbw/src/main/java/com/mycelium/wallet/lt/activity/LtMainActivity.java
@@ -40,6 +40,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.view.ViewPager;
+import android.support.v4.app.NavUtils;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBar.Tab;
 import android.support.v7.app.ActionBarActivity;
@@ -61,6 +62,7 @@ import com.mycelium.wallet.activity.AboutActivity;
 import com.mycelium.wallet.activity.export.VerifyBackupActivity;
 import com.mycelium.wallet.activity.send.InstantWalletActivity;
 import com.mycelium.wallet.activity.settings.SettingsActivity;
+import com.mycelium.wallet.activity.modern.ModernMain;
 import com.mycelium.wallet.lt.LocalTraderEventSubscriber;
 import com.mycelium.wallet.lt.LocalTraderManager;
 import com.mycelium.wallet.lt.activity.buy.SellOrderSearchFragment;
@@ -112,6 +114,8 @@ public class LtMainActivity extends ActionBarActivity {
 
       _actionBar = getSupportActionBar();
       _actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_TABS);
+      //to provide up navigation from actionbar, in case the modern main activity is not on the stack
+      _actionBar.setDisplayHomeAsUpEnabled(true);
 
       _tabsAdapter = new TabsAdapter(this, _viewPager);
 
@@ -198,6 +202,15 @@ public class LtMainActivity extends ActionBarActivity {
       final int itemId = item.getItemId();
       if (itemId == R.id.miHowTo) {
          openLocalTraderHelp();
+      }
+      if (itemId == android.R.id.home) {
+          // Respond to the action bar's home button, navigates to parent activity
+    	  // TODO: as soon as this bug is resolved, NavUtils should be used.
+    	  // http://code.google.com/p/android/issues/detail?id=58520
+          // NavUtils.navigateUpFromSameTask(this);
+    	  startActivity(new Intent(this, ModernMain.class));
+    	  
+          return true;
       }
       return super.onOptionsItemSelected(item);
    }


### PR DESCRIPTION
Added a parent activity for LtMain in the manifest.
Set "enable home as up" to true, to display the home button in local trader action bar.
Added the use of navutils to navigate up, if home button gets pressed, but commented out, since there is a bug for Android 4.1+ still to be resolved. Added a direct intent to start ModernMainActivity, to function as a workaround until the bug is resolved.
