### PR TITLE
Update Readme regarding fiat currencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ More features:
  - Sources available for review:  https://github.com/mycelium-com/wallet
  - Multiple private keys
  - Multiple Bitcoin denominations: BTC, mBTC, and uBTC
- - View your balance in multiple fiat currencies: USD, AUD, CAD, CHF, CNY, DKK, EUR, GBP, HKD, JPY, NZD, PLN, RUB, SEK, SGD, THB
+ - View your balance in 160+ fiat currencies
  - Send and receive by specifying an amount in Fiat and switch between fiat and BTC while entering the amount
  - Address book for commonly used addresses
  - Transaction history with detailed transaction details.


### PR DESCRIPTION
Since the Readme was written, there are more currencies available
for the users. They are listed in
`public/mbwapi/src/main/java/com/mrd/mbwapi/api/CurrencyCode.java`,
and currently I count 164 of them.

Update readme to be more up to date, though approximate number is enough,
does not need to mention the exact number of supported currencies,
otherwise it's a maintenance nightmare whenever a new currency is added.