### PR TITLE
Added "bits" as a Bitcoin unit. Equivalent to "μBTC".

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ We need your feedback. If you have a suggestion or a bug to report open an issue
 More features:
  - Sources available for review:  https://github.com/mycelium-com/wallet
  - Multiple private keys
- - Multiple Bitcoin denominations: BTC, mBTC, and uBTC
+ - Multiple Bitcoin denominations: BTC, mBTC, uBTC, and bits
  - View your balance in multiple fiat currencies: USD, AUD, CAD, CHF, CNY, DKK, EUR, GBP, HKD, JPY, NZD, PLN, RUB, SEK, SGD, THB
  - Send and receive by specifying an amount in Fiat and switch between fiat and BTC while entering the amount
  - Address book for commonly used addresses

--- a/public/bitlib/src/main/java/com/mrd/bitlib/util/CoinUtil.java
+++ b/public/bitlib/src/main/java/com/mrd/bitlib/util/CoinUtil.java
@@ -30,6 +30,7 @@ public class CoinUtil {
    private static final BigDecimal BTC_IN_SATOSHIS = new BigDecimal(100000000);
    private static final BigDecimal mBTC_IN_SATOSHIS = new BigDecimal(100000);
    private static final BigDecimal uBTC_IN_SATOSHIS = new BigDecimal(100);
+   private static final BigDecimal bits_IN_SATOSHIS = new BigDecimal(100);
    private static final DecimalFormat COIN_FORMAT;
 
    static {
@@ -45,7 +46,7 @@ public class CoinUtil {
 
    public enum Denomination {
       BTC(8, "BTC", "BTC", BTC_IN_SATOSHIS), mBTC(5, "mBTC", "mBTC", mBTC_IN_SATOSHIS), uBTC(2, "uBTC", "\u00B5BTC",
-            uBTC_IN_SATOSHIS);
+            uBTC_IN_SATOSHIS), bits(2, "bits", "bits", bits_IN_SATOSHIS);
 
       private final int _decimalPlaces;
       private final String _asciiString;
@@ -90,6 +91,8 @@ public class CoinUtil {
             return mBTC;
          } else if (string.equals("uBTC")) {
             return uBTC;
+         } else if (string.equals("bits")) {
+            return bits;
          } else {
             return BTC;
          }

--- a/public/mbw/src/main/java/com/mycelium/wallet/activity/settings/SettingsActivity.java
+++ b/public/mbw/src/main/java/com/mycelium/wallet/activity/settings/SettingsActivity.java
@@ -115,7 +115,7 @@ public class SettingsActivity extends PreferenceActivity {
       _bitcoinDenomination.setDefaultValue(_mbwManager.getBitcoinDenomination().toString());
       _bitcoinDenomination.setValue(_mbwManager.getBitcoinDenomination().toString());
       CharSequence[] denominations = new CharSequence[] { Denomination.BTC.toString(), Denomination.mBTC.toString(),
-            Denomination.uBTC.toString() };
+            Denomination.uBTC.toString(), Denomination.bits.toString() };
       _bitcoinDenomination.setEntries(denominations);
       _bitcoinDenomination.setEntryValues(denominations);
       _bitcoinDenomination.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {


### PR DESCRIPTION
Add an option to use "bits" as a unit of account. The average user will have a difficult time understanding "μBTC", let alone pronounce it properly.

http://en.wikipedia.org/wiki/Bit_(money)
The word bit is a colloquial expression referring to specific coins in various coinages throughout the world.