### PR TITLE
import private keys from Bitcoin Wallet backup files

### DIFF
--- a/public/mbw/src/main/java/com/mycelium/wallet/Utils.java
+++ b/public/mbw/src/main/java/com/mycelium/wallet/Utils.java
@@ -50,7 +50,9 @@ import android.graphics.drawable.Drawable;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
+import android.os.Environment;
 import android.text.ClipboardManager;
+import android.util.Base64;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
@@ -88,13 +90,30 @@ import com.mycelium.wallet.Record.Tag;
 import com.mycelium.wallet.activity.export.BackupToPdfActivity;
 import com.mycelium.wallet.activity.export.ExportAsQrCodeActivity;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.charset.Charset;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Hashtable;
 import java.util.LinkedList;
 import java.util.List;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 @SuppressWarnings("deprecation")
 public class Utils {
@@ -804,6 +823,180 @@ public class Utils {
          return;
       }
       activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
+   }
+
+   /**
+    * Search for possible backup files created by Schildbach's "Bitcoin Wallet" app
+    * (matching by filename).
+    *
+    * @return list of possible files or empty list if none found
+    */
+   public static ArrayList<File> findAndroidWalletBackupFiles(final NetworkParameters network) {
+      final File[] foundFiles;
+      final String filenamePattern;
+      if (network.isTestnet()) {
+         filenamePattern = "bitcoin-wallet-keys-testnet-\\d\\d\\d\\d-\\d\\d-\\d\\d";
+      } else {
+         filenamePattern = "bitcoin-wallet-keys-\\d\\d\\d\\d-\\d\\d-\\d\\d";
+      }
+      File backupDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+      if (backupDir.exists() && backupDir.isDirectory()) {
+         foundFiles = backupDir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String filename) {
+               return filename.matches(filenamePattern);
+            }
+         });
+         if (foundFiles.length > 1) {
+            Arrays.sort(foundFiles, new Comparator<File>() {
+               public int compare(File lhs, File rhs) {
+                  return rhs.getName().compareTo(lhs.getName());
+               }
+            });
+         }
+         return new ArrayList<File>(Arrays.asList(foundFiles));
+      }
+      return new ArrayList<File>();
+   }
+
+   /**
+    * Returns filecontent as string
+    *
+    * @param textfile
+    * @return content of textfile as string
+    * @throws java.io.IOException
+    */
+   public static String getFileContent(File textfile) throws IOException {
+      final StringBuilder filecontent = new StringBuilder();
+      final BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(textfile), Charset.forName("UTF-8")));
+      while(true) {
+         final String currLine = reader.readLine();
+         if (currLine == null) {
+            break;
+         }
+         filecontent.append(currLine);
+      }
+      return filecontent.toString();
+   }
+
+   /**
+    * Decrypt text which was encrypted with password-based AES-256-CBC as it's done by OpenSSL.
+    *
+    * @param encryptedMessageBase64 encrypted ciphertext
+    * @param password password used for encryption
+    * @return decrypted message text
+    * @throws java.security.GeneralSecurityException
+    */
+   public static String decryptOpenSslAes256Cbc(String encryptedMessageBase64, String password) throws GeneralSecurityException, UnsupportedEncodingException {
+      final String charsetNameUtf8 = "UTF-8";
+
+      // Offset from beginning of ciphertext where actual salt begins is always 8 bytes (when
+      // using OpenSSL), as OpenSSL always places the magic string "Salted__" at the beginning
+      // of the ciphertext to indicate that salt was used.
+      final int SALT_OFFSET = 8;
+      final int SALT_SIZE = 8; // next 8 bytes after header are the actual salt
+      final int CIPHERTEXT_OFFSET = SALT_OFFSET + SALT_SIZE; // after that starts the ciphertext
+
+      // As Bitcoin Wallet uses only salted encryption, we check if the ciphertext starts with
+      // the string "Salted__". Base64-encoded the first bytes of the string "Salted__"
+      // will look like "U2FsdGVkX1":
+      if (!encryptedMessageBase64.startsWith("U2FsdGVkX1")) {
+         throw new GeneralSecurityException("Ciphertext missing 'Salted__' header");
+      }
+      // Base64 decode the whole thing
+      byte[] headerSaltAndCipherText = Base64.decode(encryptedMessageBase64, Base64.DEFAULT);
+
+      byte[] salt = new byte[SALT_SIZE];
+      // starts with magic header "Salted__" so omit first 8 bytes
+      System.arraycopy(headerSaltAndCipherText, SALT_OFFSET, salt, 0, SALT_SIZE);
+      // the rest is the actual ciphertext
+      byte[] ciphertext = new byte[headerSaltAndCipherText.length - CIPHERTEXT_OFFSET];
+      System.arraycopy(headerSaltAndCipherText, CIPHERTEXT_OFFSET, ciphertext, 0, headerSaltAndCipherText.length - CIPHERTEXT_OFFSET);
+
+      Cipher aesCBC = Cipher.getInstance("AES/CBC/PKCS5Padding");
+      MessageDigest md5 = MessageDigest.getInstance("MD5");
+
+      // using getBytes(String charsetName) here as getBytes(Charset charset) is only available in API level >8
+      byte[][] keyAndIV = openSslEVP_BytesToKey(256 / Byte.SIZE, aesCBC.getBlockSize(), md5, salt, password.getBytes("UTF-8"), 1);
+      aesCBC.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyAndIV[0], "AES"), new IvParameterSpec(keyAndIV[1]));
+
+      return new String(aesCBC.doFinal(ciphertext), charsetNameUtf8);
+   }
+
+   /**
+    * Java implementation of OpenSSLs "EVP_BytesToKey()".<br/>
+    * <br/>
+    * This method is used to derive the IV and key for AES-256-CBC decryption from a given password
+    * the same way as it's done by OpenSSL when using the commandline:
+    *     "openssl enc -e -aes-256-cbc -a -in filenname.txt"
+    * <br/><br/>
+    * Thanks to Ola Bini for releasing sourcecode for this method on his blog.
+    * This implementation is based on the sourcecode obtained from
+    * http://olabini.com/blog/tag/evp_bytestokey/ (last accessed at May 08, 2014)
+    * where it was released into public domain ("note, I release this into the public domain").
+    */
+   private static byte[][] openSslEVP_BytesToKey(int key_len, int iv_len, MessageDigest md, byte[] salt, byte[] data, int iterations) {
+      byte[][] keyAndIv = new byte[2][];
+      byte[] key = new byte[key_len];
+      int key_ix = 0;
+      byte[] iv = new byte[iv_len];
+      int iv_ix = 0;
+      keyAndIv[0] = key;
+      keyAndIv[1] = iv;
+      byte[] md_buf = null;
+      int nkey = key_len;
+      int niv = iv_len;
+      int i = 0;
+      if (data == null) {
+         return keyAndIv;
+      }
+      int addmd = 0;
+      for (;;) {
+         md.reset();
+         if (addmd++ > 0) {
+            md.update(md_buf);
+         }
+         md.update(data);
+         if (null != salt) {
+            md.update(salt, 0, 8);
+         }
+         md_buf = md.digest();
+         for (i = 1; i < iterations; i++) {
+            md.reset();
+            md.update(md_buf);
+            md_buf = md.digest();
+         }
+         i = 0;
+         if (nkey > 0) {
+            for (;;) {
+               if (nkey == 0)
+                  break;
+               if (i == md_buf.length)
+                  break;
+               key[key_ix++] = md_buf[i];
+               nkey--;
+               i++;
+            }
+         }
+         if (niv > 0 && i != md_buf.length) {
+            for (;;) {
+               if (niv == 0)
+                  break;
+               if (i == md_buf.length)
+                  break;
+               iv[iv_ix++] = md_buf[i];
+               niv--;
+               i++;
+            }
+         }
+         if (nkey == 0 && niv == 0) {
+            break;
+         }
+      }
+      for (i = 0; i < md_buf.length; i++) {
+         md_buf[i] = 0;
+      }
+      return keyAndIv;
    }
 
 }

--- a/public/mbw/src/main/java/com/mycelium/wallet/activity/AddRecordActivity.java
+++ b/public/mbw/src/main/java/com/mycelium/wallet/activity/AddRecordActivity.java
@@ -35,11 +35,14 @@
 package com.mycelium.wallet.activity;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.view.View;
 import android.view.WindowManager;
+import android.widget.EditText;
 import android.widget.Toast;
 
 import com.mrd.bitlib.model.NetworkParameters;
@@ -49,6 +52,16 @@ import com.mycelium.wallet.Record;
 import com.mycelium.wallet.Record.BackupState;
 import com.mycelium.wallet.Record.Source;
 import com.mycelium.wallet.Utils;
+import com.mycelium.wallet.activity.modern.Toaster;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class AddRecordActivity extends Activity {
 
@@ -60,6 +73,7 @@ public class AddRecordActivity extends Activity {
    public static final String RESULT_KEY = "record";
    private static final int SCAN_RESULT_CODE = 0;
    private static final int CREATE_RESULT_CODE = 1;
+   private Toaster _toaster;
 
    private NetworkParameters _network;
 
@@ -70,6 +84,7 @@ public class AddRecordActivity extends Activity {
       setContentView(R.layout.add_record_activity);
       final Activity activity = AddRecordActivity.this;
       _network = MbwManager.getInstance(this).getNetwork();
+      _toaster= new Toaster(this);
 
       findViewById(R.id.btScan).setOnClickListener(new View.OnClickListener() {
 
@@ -100,7 +115,21 @@ public class AddRecordActivity extends Activity {
 
       });
 
-      findViewById(R.id.btRandom).setOnClickListener(new View.OnClickListener() {
+      if (Utils.findAndroidWalletBackupFiles(_network).size() > 0) {
+         findViewById(R.id.llAndroidWalletBackup).setVisibility(View.VISIBLE);
+         findViewById(R.id.btAndroidWalletBackup).setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+               importAndroidWalletDialog(Utils.findAndroidWalletBackupFiles(_network));
+            }
+
+         });
+      } else {
+         findViewById(R.id.llAndroidWalletBackup).setVisibility(View.GONE);
+      }
+
+       findViewById(R.id.btRandom).setOnClickListener(new View.OnClickListener() {
 
          @Override
          public void onClick(View v) {
@@ -149,6 +178,100 @@ public class AddRecordActivity extends Activity {
       result.putExtra("record", record);
       setResult(RESULT_OK, result);
       finish();
+   }
+
+   /**
+    * Show alert dialog with list of found "Bitcoin Wallet" backup files to import from.
+    * Starts import for chosen file.
+    * @param backupList list of possible Android Wallet backup files
+    */
+   private void importAndroidWalletDialog(final List<File> backupList) {
+      AlertDialog.Builder builder = new AlertDialog.Builder(this);
+      CharSequence[] names = new CharSequence[backupList.size()];
+      int pos = 0;
+      for (File f : backupList) {
+         names[pos] = f.getName();
+         pos++;
+      }
+      builder.setTitle(R.string.pick_android_wallet_backup);
+      builder.setItems(names, new DialogInterface.OnClickListener() {
+         public void onClick(DialogInterface dialog, int which) {
+            androidWalletPasswordDialog(backupList.get(which));
+         }
+      });
+      builder.create().show();
+   }
+
+   /**
+    * Shows alert dialog with EditText field for entering decryption password
+    * of Android wallet backup.
+    * @param backupFile chosen backup file to decrypt
+    */
+   private void androidWalletPasswordDialog(final File backupFile) {
+      AlertDialog.Builder builder = new AlertDialog.Builder(this);
+      builder.setTitle(R.string.enter_android_wallet_backup_password_title);
+      builder.setMessage(R.string.enter_android_wallet_backup_password_message);
+      final EditText input = new EditText(this);
+      builder.setView(input);
+      builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+         public void onClick(DialogInterface dialog, int whichButton) {
+            try {
+               String password = input.getText().toString();
+               String decryptedText = Utils.decryptOpenSslAes256Cbc(Utils.getFileContent(backupFile), password);
+               chooseKeyForImportDialog(parseRecordsFromBackupText(decryptedText));
+            } catch (GeneralSecurityException se) {
+               _toaster.toast(R.string.import_android_wallet_backup_decryption_error, false);
+            } catch (IOException io) {
+               _toaster.toast(R.string.import_android_wallet_backup_io_error, false);
+            }
+         }
+      });
+      builder.show();
+   }
+
+   /**
+    * Shows a list with found Bitcoin addresses in the "Bitcoin Wallet" backup file,
+    * returns the one the user chooses to the calling activity
+    * @param recordList list of found Records in backup file
+    */
+   private void chooseKeyForImportDialog(final List<Record> recordList) {
+      AlertDialog.Builder builder = new AlertDialog.Builder(this);
+      CharSequence[] keys = new CharSequence[recordList.size()];
+      int pos = 0;
+      for (Record rec : recordList) {
+         keys[pos] = rec.address.toString();
+         pos++;
+      }
+      builder.setTitle(R.string.pick_android_wallet_address_for_import).setItems(keys, new DialogInterface.OnClickListener() {
+         public void onClick(DialogInterface dialog, int which) {
+            finishOk(recordList.get(which), BackupState.UNKNOWN);
+         }
+      });
+      builder.create().show();
+   }
+
+   /**
+    * Parse possible Base58 private keys from text (as used in "Bitcoin Wallet" backup files)
+    * @param plainBackupText
+    * @return list of found records
+    */
+   private List<Record> parseRecordsFromBackupText(String plainBackupText) {
+      StringTokenizer lines = new StringTokenizer(plainBackupText, "\n", false);
+      List<Record> foundRecords = new ArrayList<Record>();
+      // single line with key looks like:
+      // KzCxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 2014-02-11T08:55:35Z
+      Pattern p = Pattern.compile("^([A-Za-z0-9]{30,60}) \\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\dZ$");
+      while (lines.hasMoreTokens()) {
+         String currLine = lines.nextToken();
+         Matcher m = p.matcher(currLine);
+         if(m.matches()) {
+            Record importRec = Record.recordFromBase58Key(m.group(1), _network);
+            if (importRec!=null) {
+               foundRecords.add(importRec);
+            }
+         }
+      }
+      return foundRecords;
    }
 
 }

--- a/public/mbw/src/main/res/layout/add_record_activity.xml
+++ b/public/mbw/src/main/res/layout/add_record_activity.xml
@@ -103,6 +103,47 @@
             android:paddingLeft="30dp"
             android:paddingRight="30dp"
             android:text="@string/clipboard" />
+
+
+        <!-- UI elements for importing keys from backup created by Schildbach "Bitcoin Wallet": -->
+        <LinearLayout
+            android:id="@+id/llAndroidWalletBackup"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="vertical" >
+
+            <View
+                android:layout_width="wrap_content"
+                android:layout_height="20dp" >
+            </View>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/import_from_android_wallet_backup_desc" />
+
+            <View
+                android:layout_width="wrap_content"
+                android:layout_height="5dp" >
+            </View>
+
+            <Button
+                android:id="@+id/btAndroidWalletBackup"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:paddingLeft="30dp"
+                android:paddingRight="30dp"
+                android:text="@string/android_wallet_backup" />
+
+            <View
+                android:layout_width="wrap_content"
+                android:layout_height="5dp" >
+            </View>
+
+        </LinearLayout>
     </LinearLayout>
 
 </ScrollView>

--- a/public/mbw/src/main/res/values-de/strings.xml
+++ b/public/mbw/src/main/res/values-de/strings.xml
@@ -10,6 +10,14 @@
   <string name="scan">Scannen</string>
   <string name="clipboard">Zwischenablage</string>
   <string name="random">Zufällig</string>
+  <string name="import_from_android_wallet_backup_desc">Private Schlüssel aus einem Backup der App \"Bitcoin Wallet\" von Andreas Schildbach importieren.</string>
+  <string name="android_wallet_backup">Bitcoin Wallet Backup</string>
+  <string name="pick_android_wallet_backup">Bitte eine Backup Datei auswählen</string>
+  <string name="enter_android_wallet_backup_password_title">Passwort des Backups</string>
+  <string name="enter_android_wallet_backup_password_message">Bitte das Passwort eingeben, das in der App \"Bitcoin Wallet\" beim Erstellen des Backups benutzt wurde.</string>
+  <string name="pick_android_wallet_address_for_import">Welche Adresse soll importiert werden?</string>
+  <string name="import_android_wallet_backup_io_error">Fehler beim Lesen der Bitcoin Wallet Backup Datei.</string>
+  <string name="import_android_wallet_backup_decryption_error">Backup Datei konnte nicht entschlüsselt werden. Ist das eingegebene Passwort korrekt?</string>
   <string name="close">Schließen</string>
   <string name="sending">Sende %1$s</string>
   <string name="receiving">Empfange %1$s</string>

--- a/public/mbw/src/main/res/values/strings.xml
+++ b/public/mbw/src/main/res/values/strings.xml
@@ -10,6 +10,14 @@
     <string name="random_desc">Create a new random private key.</string>
     <string name="scan">Scan</string>
     <string name="clipboard">Clipboard</string>
+    <string name="import_from_android_wallet_backup_desc">Import Bitcoin private key from a backup created by the \"Bitcoin Wallet\" app from Andreas Schildbach.</string>
+    <string name="android_wallet_backup">Bitcoin Wallet Backup</string>
+    <string name="pick_android_wallet_backup">Pick a backup file</string>
+    <string name="enter_android_wallet_backup_password_title">Backup password</string>
+    <string name="enter_android_wallet_backup_password_message">Enter the password that was used when creating the backup in the \"Bitcoin Wallet\" app.</string>
+    <string name="pick_android_wallet_address_for_import">Pick an address for import</string>
+    <string name="import_android_wallet_backup_io_error">Could not read the Bitcoin Wallet backup file.</string>
+    <string name="import_android_wallet_backup_decryption_error">Could not decrypt the Bitcoin Wallet backup file. Is the password correct?</string>
     <string name="random">Random</string>
     <string name="close">Close</string>
     <string name="btc_value_string">%1$s %2$s</string>


### PR DESCRIPTION
Adds a new button to the AddRecordActivity which allows the import of private keys from backup files created by the Schildbach "Bitcoin Wallet" app. Didn't create a new Activity but simply added AlertDialogs to AddRecordActivity (don't know if you'd prefer to have this in separate Activity).

Some details:
- button is not shown if no backup files exist
- works with testnet and prodnet
- allows to choose which file to import
- allows to choose which key from the file to import
- english and german strings included
- uses javax.crypto.Cipher class to decrypt the AES-256-CBC enciphered backups (uses no code from the Schildbach Bitcoin Wallet)

![device-2014-05-08-223900](https://cloud.githubusercontent.com/assets/285900/2921372/9f08505e-d6f2-11e3-87a4-e01a3e90e5d0.jpg)
![device-2014-05-08-223912](https://cloud.githubusercontent.com/assets/285900/2921374/a5f66cde-d6f2-11e3-84f4-ab78f24577a9.jpg)
![device-2014-05-08-223950](https://cloud.githubusercontent.com/assets/285900/2921378/ad2142fe-d6f2-11e3-8e25-5d4a3adb5e3b.jpg)
![device-2014-05-08-224006](https://cloud.githubusercontent.com/assets/285900/2921381/b0b63b68-d6f2-11e3-852c-4559e13c38fb.jpg)
![device-2014-05-08-224040](https://cloud.githubusercontent.com/assets/285900/2921385/b29b5710-d6f2-11e3-9ea6-ab5932efa449.jpg)
![device-2014-05-08-224119](https://cloud.githubusercontent.com/assets/285900/2921386/b50088f4-d6f2-11e3-86db-5561b565991f.jpg)
![device-2014-05-08-224131](https://cloud.githubusercontent.com/assets/285900/2921387/b742bf1a-d6f2-11e3-8c0e-2616ae1140b1.jpg)
