### PR TITLE
don't finish InstantWalletActivity on scan result

### DIFF
--- a/public/mbw/src/main/java/com/mycelium/wallet/activity/send/InstantWalletActivity.java
+++ b/public/mbw/src/main/java/com/mycelium/wallet/activity/send/InstantWalletActivity.java
@@ -126,7 +126,8 @@ public class InstantWalletActivity extends Activity {
                   .getSerializableExtra(ScanActivity.RESULT_RECORD_KEY));
             Wallet wallet = new Wallet(record);
             SendInitializationActivity.callMe(this, wallet, _amountToSend, _receivingAddress, true);
-            finish();
+            // We don't call finish() here, so that this activity stays on the back stack.
+            // So the user can click back and scan the next cold storage.
          } else {
             ScanActivity.toastScanError(resultCode, intent, this);
          }


### PR DESCRIPTION
Suggestion for a very minor usability change:
Don't finish() the InstantWallerActivity after the user has scanned a cold storage QR code. This way the activity stays on the back stack and the user only needs to press the "back" key and the "QR code" button again (= 2 clicks) for scanning the next QR code.

Useful for scanning/checking the balances of cold storages in bulk.
