### PR TITLE
activate clipboard button even if there is only an address in clipboard

### DIFF
--- a/public/mbw/src/main/java/com/mycelium/wallet/activity/send/InstantWalletActivity.java
+++ b/public/mbw/src/main/java/com/mycelium/wallet/activity/send/InstantWalletActivity.java
@@ -85,7 +85,7 @@ public class InstantWalletActivity extends Activity {
       _receivingAddress = (Address) getIntent().getSerializableExtra("receivingAddress");
 
       final Record record = getRecordFromClipboard();
-      if (record == null || !record.hasPrivateKey()) {
+      if (record == null) {
          findViewById(R.id.btClipboard).setEnabled(false);
       } else {
          findViewById(R.id.btClipboard).setOnClickListener(new OnClickListener() {


### PR DESCRIPTION
Small suggestion for the InstantWalletActivity (Cold storage screen):

The user can scan a QR code or paste a key from the clipboard. When scanning a QR code it is also possible to just scan an address without key (for verifying the balance).

This is not possible when using the clipboard (the clipboard button is disabled if the clipboard just contains an address and not a private key).

This small patch enables the clipboard button if there is just an address (and no key) on the clipboard (to be consistent with the behaviour when scanning a QR code)
