### PR TITLE
Fix Unplugged AID visibility

### DIFF
--- a/public/mbw/src/main/java/com/mycelium/wallet/activity/settings/SettingsActivity.java
+++ b/public/mbw/src/main/java/com/mycelium/wallet/activity/settings/SettingsActivity.java
@@ -470,11 +470,11 @@ public class SettingsActivity extends PreferenceActivity {
       if (isTeeAvailable) {
          _ledgerDisableTee.setChecked(_mbwManager.getLedgerManager().getDisableTEE());
          _ledgerDisableTee.setOnPreferenceClickListener(onClickLedgerNotificationDisableTee);
-         _ledgerSetUnpluggedAID.setOnPreferenceClickListener(onClickLedgerSetUnpluggedAID);
       } else {
-         getPreferenceScreen().removePreference(findPreference("ledger"));
+	 getPreferenceScreen().removePreference(findPreference("ledgerDisableTee"));
       }
-
+      
+      _ledgerSetUnpluggedAID.setOnPreferenceClickListener(onClickLedgerSetUnpluggedAID);
 
       applyLocalTraderEnablement();
    }


### PR DESCRIPTION
Ledger Unplugged AID option should always be visible as it's not related to the TEE, and is mandatory to use a non Fidesmo implementation