### PR TITLE
BIP39 uses passphrases not passwords

### DIFF
--- a/public/bitlib/src/test/java/com/mrd/bitlib/Bip39Test.java
+++ b/public/bitlib/src/test/java/com/mrd/bitlib/Bip39Test.java
@@ -146,7 +146,7 @@ public class Bip39Test {
          String[] wordList = TEST_VECTORS[i * 3 + 1].split(" ");
          Bip39.MasterSeed masterSeed = Bip39.generateSeedFromWordList(wordList, "TREZOR");
          assertEquals(TEST_VECTORS[i * 3 + 2], HexUtils.toHex(masterSeed.getBip32Seed()));
-         assertEquals(masterSeed.getBip39Password(), "TREZOR");
+         assertEquals(masterSeed.getBip39Passphrase(), "TREZOR");
       }
    }
 
@@ -174,11 +174,11 @@ public class Bip39Test {
    }
 
    @Test
-   public void testNoPassword() {
+   public void testNoPassphrase() {
       String[] wordList = TEST_NO_PASSWORD_WORDS.split(" ");
       Bip39.MasterSeed masterSeed = Bip39.generateSeedFromWordList(wordList, "");
       assertEquals(TEST_NO_PASSWORD_SEED, HexUtils.toHex(masterSeed.getBip32Seed()));
-      assertTrue(masterSeed.getBip39Password().length() == 0);
+      assertTrue(masterSeed.getBip39Passphrase().length() == 0);
    }
 
 }

--- a/public/mbw/src/main/java/com/mycelium/wallet/activity/BackupWordListActivity.java
+++ b/public/mbw/src/main/java/com/mycelium/wallet/activity/BackupWordListActivity.java
@@ -82,7 +82,7 @@ public class BackupWordListActivity extends ActionBarActivity {
       }
 
       wordlist = masterSeed.getBip39WordList();
-      password = masterSeed.getBip39Password();
+      password = masterSeed.getBip39Passphrase();
       currentWordIndex = 0;
 
       btnNextWord = (Button)findViewById(R.id.btOkay);

--- a/public/mbw/src/main/java/com/mycelium/wallet/activity/EnterWordListActivity.java
+++ b/public/mbw/src/main/java/com/mycelium/wallet/activity/EnterWordListActivity.java
@@ -84,7 +84,7 @@ public class EnterWordListActivity extends ActionBarActivity implements WordAuto
    private ProgressDialog _progress;
    private TextView enterWordInfo;
    private List<String> enteredWords;
-   private boolean usesPassword;
+   private boolean usesPassphrase;
    private int numberOfWords;
    private int currentWordNum;
    private WordAutoCompleterFragment _wordAutoCompleter;
@@ -116,7 +116,7 @@ public class EnterWordListActivity extends ActionBarActivity implements WordAuto
 
    private void askForWordNumber() {
       final View checkBoxView = View.inflate(this, R.layout.wordlist_checkboxes, null);
-      final CheckBox checkBox = (CheckBox) checkBoxView.findViewById(R.id.checkboxWordlistPassword);
+      final CheckBox checkBox = (CheckBox) checkBoxView.findViewById(R.id.checkboxWordlistPassphrase);
       final RadioButton words12 = (RadioButton) checkBoxView.findViewById(R.id.wordlist12);
       final RadioButton words18 = (RadioButton) checkBoxView.findViewById(R.id.wordlist18);
       final RadioButton words24 = (RadioButton) checkBoxView.findViewById(R.id.wordlist24);
@@ -125,9 +125,9 @@ public class EnterWordListActivity extends ActionBarActivity implements WordAuto
          @Override
          public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
             if (b) {
-               checkBoxView.findViewById(R.id.tvPasswordInfo).setVisibility(View.VISIBLE);
+               checkBoxView.findViewById(R.id.tvPassphraseInfo).setVisibility(View.VISIBLE);
             } else {
-               checkBoxView.findViewById(R.id.tvPasswordInfo).setVisibility(View.GONE);
+               checkBoxView.findViewById(R.id.tvPassphraseInfo).setVisibility(View.GONE);
             }
          }
       });
@@ -139,7 +139,7 @@ public class EnterWordListActivity extends ActionBarActivity implements WordAuto
             .setCancelable(false)
             .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                public void onClick(DialogInterface dialog, int id) {
-                  usesPassword = checkBox.isChecked();
+                  usesPassphrase = checkBox.isChecked();
                   if (words12.isChecked()) {
                      numberOfWords = 12;
                   } else if (words18.isChecked()) {
@@ -188,14 +188,14 @@ public class EnterWordListActivity extends ActionBarActivity implements WordAuto
       enteredWords.add(selection);
       enterWordInfo.setText(enteredWords.toString());
       if (checkIfDone()) {
-         askForPassword();
+         askForPassphrase();
       } else {
          findViewById(R.id.btDeleteLastWord).setEnabled(true);
       }
    }
 
-   private void askForPassword() {
-      if (usesPassword) {
+   private void askForPassphrase() {
+      if (usesPassphrase) {
          final EditText pass = new EditText(this);
 
          AlertDialog.Builder builder = new AlertDialog.Builder(this);
@@ -320,7 +320,7 @@ public class EnterWordListActivity extends ActionBarActivity implements WordAuto
    @Override
    public void onSaveInstanceState(Bundle savedInstanceState) {
       super.onSaveInstanceState(savedInstanceState);
-      savedInstanceState.putBoolean("usepass", usesPassword);
+      savedInstanceState.putBoolean("usepass", usesPassphrase);
       savedInstanceState.putInt("index", currentWordNum);
       savedInstanceState.putInt("total", numberOfWords);
       savedInstanceState.putStringArray("entered", enteredWords.toArray(new String[enteredWords.size()]));
@@ -331,7 +331,7 @@ public class EnterWordListActivity extends ActionBarActivity implements WordAuto
       super.onRestoreInstanceState(savedInstanceState);
       enteredWords = new ArrayList<String>(Arrays.asList(savedInstanceState.getStringArray("entered")));
       enterWordInfo.setText(enteredWords.toString());
-      usesPassword = savedInstanceState.getBoolean("usepass");
+      usesPassphrase = savedInstanceState.getBoolean("usepass");
       numberOfWords = savedInstanceState.getInt("total");
       currentWordNum = savedInstanceState.getInt("index");
       findViewById(R.id.btDeleteLastWord).setEnabled(currentWordNum > 1);

--- a/public/mbw/src/main/java/com/mycelium/wallet/activity/VerifyWordListActivity.java
+++ b/public/mbw/src/main/java/com/mycelium/wallet/activity/VerifyWordListActivity.java
@@ -83,7 +83,7 @@ public class VerifyWordListActivity extends ActionBarActivity implements WordAut
       }
 
       wordlist = masterSeed.getBip39WordList();
-      password = masterSeed.getBip39Password();
+      password = masterSeed.getBip39Passphrase();
       currentWordIndex = 0;
 
       _wordAutoCompleter = (WordAutoCompleterFragment) getSupportFragmentManager().findFragmentById(R.id.wordAutoCompleter);

--- a/public/mbw/src/main/res/layout/wordlist_checkboxes.xml
+++ b/public/mbw/src/main/res/layout/wordlist_checkboxes.xml
@@ -42,16 +42,16 @@
 
 
         <CheckBox
-                android:id="@+id/checkboxWordlistPassword"
+                android:id="@+id/checkboxWordlistPassphrase"
                 style="?android:attr/textAppearanceMedium"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="10dp"
                 android:layout_marginRight="10dp"
-                android:text="@string/checkbox_wordlist_password"/>
+                android:text="@string/checkbox_wordlist_passphrase"/>
 
         <TextView
-                android:id="@+id/tvPasswordInfo"
+                android:id="@+id/tvPassphraseInfo"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textSize="12sp"
@@ -59,7 +59,7 @@
                 android:layout_marginRight="10dp"
                 android:layout_marginBottom="5dp"
                 android:visibility="gone"
-                android:text="@string/recover_seed_password_info"
+                android:text="@string/recover_seed_passphrase_info"
                 />
     </LinearLayout>
 </ScrollView>

--- a/public/mbw/src/main/res/values-de/strings.xml
+++ b/public/mbw/src/main/res/values-de/strings.xml
@@ -486,11 +486,11 @@ Schlüsseln und das Ändern des PIN-Codes verbietet
   <string name="account_contains_one_address_info">Enthält eine Adresse.</string>
   <string name="verify_backup_ok_message">Das Backup wurde erfolgreich überprüft.</string>
   <string name="wordlist_import_invalid_checksum">Die Prüfsumme Ihrer Wortliste ist ungültig, bitte stellen Sie sicher, dass Sie alle Wörter korrekt eingegeben haben.</string>
-  <string name="checkbox_wordlist_password">Ich habe ein Passwort</string>
+  <string name="checkbox_wordlist_passphrase">Ich habe ein Passwort</string>
   <string name="wordlist_length_12">12 Wörter</string>
   <string name="wordlist_length_18">18 Wörter</string>
   <string name="wordlist_length_24">24 Wörter</string>
-  <string name="recover_seed_password_info">Wählen Sie diese Option nur, wenn Sie verstehen, was sie bedeutet. \n Ein normales Mycelium Backup enthält niemals ein Passwort - dies ist nicht Ihre PIN.</string>
+  <string name="recover_seed_passphrase_info">Wählen Sie diese Option nur, wenn Sie verstehen, was sie bedeutet. \n Ein normales Mycelium Backup enthält niemals ein Passwort - dies ist nicht Ihre PIN.</string>
   <string name="import_wordlist_questions">Bitte wählen Sie die Länge der zu importierenden Wortliste um anzugeben, ob sie mittels Kennwort geschützt ist.</string>
   <string name="type_password_title">Geben Sie Ihr Passwort ein</string>
   <string name="clipboard_not_available">Inhalt der Zwischenablage nicht gültig</string>

--- a/public/mbw/src/main/res/values-el/strings.xml
+++ b/public/mbw/src/main/res/values-el/strings.xml
@@ -482,11 +482,11 @@
   <string name="account_contains_one_address_info">Περιέχει μια διεύθυνση.</string>
   <string name="verify_backup_ok_message">Το αντίγραφο ασφαλείας επιβεβαιώθηκε επιτυχώς.</string>
   <string name="wordlist_import_invalid_checksum">Το ψηφίο επιβεβαίωσης της λίστας λέξεών σας είναι μη έγκυρο, παρακαλώ σιγουρευτείτε ότι εισαγάγατε όλες τις λέξεις σωστά.</string>
-  <string name="checkbox_wordlist_password">Έχω κωδικό πρόσβασης</string>
+  <string name="checkbox_wordlist_passphrase">Έχω κωδικό πρόσβασης</string>
   <string name="wordlist_length_12">12 λέξεις</string>
   <string name="wordlist_length_18">18 λέξεις</string>
   <string name="wordlist_length_24">24 λέξεις</string>
-  <string name="recover_seed_password_info">Τσεκάρετε αυτή την επιλογή μόνο εάν κατανοείτε τι σημαίνει.\nΈνα κανονικό αντίγραφο ασφαλείας του Mycelium ποτέ δεν περιλαμβάνει κωδικό πρόσβασης - αυτός δεν είναι o κωδικός PIN.</string>
+  <string name="recover_seed_passphrase_info">Τσεκάρετε αυτή την επιλογή μόνο εάν κατανοείτε τι σημαίνει.\nΈνα κανονικό αντίγραφο ασφαλείας του Mycelium ποτέ δεν περιλαμβάνει κωδικό πρόσβασης - αυτός δεν είναι o κωδικός PIN.</string>
   <string name="import_wordlist_questions">Παρακαλώ επιλέξτε το μέγεθος της λίστας λέξεων γι\' αποκατάσταση, και υποδείξτε εάν προστατεύεται από κωδικό πρόσβασης.</string>
   <string name="type_password_title">Εισαγάγετε τον Κωδικό Πρόσβασης</string>
   <string name="clipboard_not_available">Μη έγκυρο πρόχειρο</string>

--- a/public/mbw/src/main/res/values-fr/strings.xml
+++ b/public/mbw/src/main/res/values-fr/strings.xml
@@ -484,11 +484,11 @@
   <string name="account_contains_one_address_info">Contient une adresse.</string>
   <string name="verify_backup_ok_message">La sauvegarde a été vérifiée avec succès.</string>
   <string name="wordlist_import_invalid_checksum">Le checksum de votre liste de mots a échoué, veuillez vérifier que vous avez entré tous les mots correctement.</string>
-  <string name="checkbox_wordlist_password">J\'ai un mot de passe</string>
+  <string name="checkbox_wordlist_passphrase">J\'ai un mot de passe</string>
   <string name="wordlist_length_12">12 mots</string>
   <string name="wordlist_length_18">18 mots</string>
   <string name="wordlist_length_24">24 mots</string>
-  <string name="recover_seed_password_info">Sélectionnez uniquement cette option si vous comprenez ce qu\'elle signifie.\nUne sauvegarde normale de Mycelium n\'inclut jamais un mot de passe - ce n\'est pas votre code d\'accès.</string>
+  <string name="recover_seed_passphrase_info">Sélectionnez uniquement cette option si vous comprenez ce qu\'elle signifie.\nUne sauvegarde normale de Mycelium n\'inclut jamais un mot de passe - ce n\'est pas votre code d\'accès.</string>
   <string name="import_wordlist_questions">Veuillez sélectionner la longueur de votre liste de mots à restaurer et indiquer si cette liste est protégée par un mot de passe.</string>
   <string name="type_password_title">Entrer votre mot de passe</string>
   <string name="clipboard_not_available">Presse-papier non valide</string>

--- a/public/mbw/src/main/res/values-it/strings.xml
+++ b/public/mbw/src/main/res/values-it/strings.xml
@@ -467,7 +467,7 @@
   <string name="account_contains_one_address_info">Contiene un indirizzo.</string>
   <string name="verify_backup_ok_message">Backup verificato con successo.</string>
   <string name="wordlist_import_invalid_checksum">Il checksum della tua wordlist non è valido, assicurati di aver inserito correttamente tutte le parole.</string>
-  <string name="checkbox_wordlist_password">Ho una password</string>
+  <string name="checkbox_wordlist_passphrase">Ho una password</string>
   <string name="wordlist_length_12">12 parole</string>
   <string name="wordlist_length_18">18 parole</string>
   <string name="wordlist_length_24">24 parole</string>

--- a/public/mbw/src/main/res/values-ja/strings.xml
+++ b/public/mbw/src/main/res/values-ja/strings.xml
@@ -480,11 +480,11 @@
   <string name="account_contains_one_address_info">１個のアドレスを含みます。</string>
   <string name="verify_backup_ok_message">バックアップの確認に成功しました。</string>
   <string name="wordlist_import_invalid_checksum">ワードリストのチェックサムは無効です。すべてのワードが正しいかご確認下さい。</string>
-  <string name="checkbox_wordlist_password">パスワードがあります</string>
+  <string name="checkbox_wordlist_passphrase">パスワードがあります</string>
   <string name="wordlist_length_12">12ワード</string>
   <string name="wordlist_length_18">18ワード</string>
   <string name="wordlist_length_24">24ワード</string>
-  <string name="recover_seed_password_info">意味がわからなければ、この選択はしないで下さい。\n通常のMyceliumバックアップはパスワードは決して含みません。これはピンナンバーではありません。</string>
+  <string name="recover_seed_passphrase_info">意味がわからなければ、この選択はしないで下さい。\n通常のMyceliumバックアップはパスワードは決して含みません。これはピンナンバーではありません。</string>
   <string name="import_wordlist_questions">復元するためワードリストの長さを選択し、パスワードによって保護されるかどうかを決定してください。</string>
   <string name="type_password_title">パスワードを入力してください</string>
   <string name="clipboard_not_available">クリップボードは無効です。</string>

--- a/public/mbw/src/main/res/values-nl/strings.xml
+++ b/public/mbw/src/main/res/values-nl/strings.xml
@@ -484,11 +484,11 @@
   <string name="account_contains_one_address_info">Bevat één adres.</string>
   <string name="verify_backup_ok_message">De back-up is met succes geverifieerd.</string>
   <string name="wordlist_import_invalid_checksum">De checksum van uw woordenlijst is ongeldig, zorg ervoor dat u alle woorden correct hebt ingevoerd.</string>
-  <string name="checkbox_wordlist_password">Ik heb een wachtwoord</string>
+  <string name="checkbox_wordlist_passphrase">Ik heb een wachtwoord</string>
   <string name="wordlist_length_12">12 woorden</string>
   <string name="wordlist_length_18">18 woorden</string>
   <string name="wordlist_length_24">24 woorden</string>
-  <string name="recover_seed_password_info">Selecteer deze optie alleen als u begrijpt wat het betekent.\nEen normale Mycelium back-up heeft nooit een wachtwoord - dit is niet uw PIN.</string>
+  <string name="recover_seed_passphrase_info">Selecteer deze optie alleen als u begrijpt wat het betekent.\nEen normale Mycelium back-up heeft nooit een wachtwoord - dit is niet uw PIN.</string>
   <string name="import_wordlist_questions">Selecteer de lengte van de woordenlijst die u wenst te herstellen en geef aan of deze beveiligd is met een wachtwoord.</string>
   <string name="type_password_title">Voer uw wachtwoord in</string>
   <string name="clipboard_not_available">Klembord niet beschikbaar</string>

--- a/public/mbw/src/main/res/values-ru/strings.xml
+++ b/public/mbw/src/main/res/values-ru/strings.xml
@@ -484,11 +484,11 @@
   <string name="account_contains_one_address_info">Содержит один адрес.</string>
   <string name="verify_backup_ok_message">Резервная Копия успешно проверена.</string>
   <string name="wordlist_import_invalid_checksum">Контрольная сумма вашего списка слов является недействительной, пожалуйста, убедитесь, что вы правильно ввели все слова.</string>
-  <string name="checkbox_wordlist_password">У меня есть пароль</string>
+  <string name="checkbox_wordlist_passphrase">У меня есть пароль</string>
   <string name="wordlist_length_12">12 слов</string>
   <string name="wordlist_length_18">18 слов</string>
   <string name="wordlist_length_24">24 слов</string>
-  <string name="recover_seed_password_info">ВЫберете эту опцию, если вы понимаете, что она значит.\nОбычная резервная копия Mycelium не содержит вашего пароля и это не ваш PIN.</string>
+  <string name="recover_seed_passphrase_info">ВЫберете эту опцию, если вы понимаете, что она значит.\nОбычная резервная копия Mycelium не содержит вашего пароля и это не ваш PIN.</string>
   <string name="import_wordlist_questions">Пожалуйста, выбере размер списка слов для восстановления, и укажите, надо ли использовать защиту паролем.</string>
   <string name="type_password_title">Введите свой пароль</string>
   <string name="clipboard_not_available">В буфере обмена нет правильных данных</string>

--- a/public/mbw/src/main/res/values-sl/strings.xml
+++ b/public/mbw/src/main/res/values-sl/strings.xml
@@ -482,11 +482,11 @@
   <string name="account_contains_one_address_info">Vsebuje en naslov.</string>
   <string name="verify_backup_ok_message">Rezervna kopija je bila uspešno preverjena.</string>
   <string name="wordlist_import_invalid_checksum">Kontrolna vsota vnesenega niza besed je neveljavna. Prosimo, preverite, da ste pravilno vnesli besede.</string>
-  <string name="checkbox_wordlist_password">Imam geslo</string>
+  <string name="checkbox_wordlist_passphrase">Imam geslo</string>
   <string name="wordlist_length_12">12 besed</string>
   <string name="wordlist_length_18">18 besed</string>
   <string name="wordlist_length_24">24 besed</string>
-  <string name="recover_seed_password_info">Izberite to možnost le, če razumete, kaj pomeni.\nObičajna rezervna kopija v Myceliumu nikoli ne vsebuje gesla - to ni vaša PIN-koda.</string>
+  <string name="recover_seed_passphrase_info">Izberite to možnost le, če razumete, kaj pomeni.\nObičajna rezervna kopija v Myceliumu nikoli ne vsebuje gesla - to ni vaša PIN-koda.</string>
   <string name="import_wordlist_questions">Prosimo, izberite dolžino niza besed, ki ga želite uporabiti, in označite, ali je niz zaščiten z geslom.</string>
   <string name="type_password_title">Vnesite svoje geslo</string>
   <string name="clipboard_not_available">Odložišče ni na voljo ali veljavno.</string>

--- a/public/mbw/src/main/res/values-sq/strings.xml
+++ b/public/mbw/src/main/res/values-sq/strings.xml
@@ -482,11 +482,11 @@
   <string name="account_contains_one_address_info">Përmban një adresë.</string>
   <string name="verify_backup_ok_message">Kopja rezervë u verifikua me sukses.</string>
   <string name="wordlist_import_invalid_checksum">\"Checksum\" i listës së fjalëve tuaja është jovalid, ju lutem sigurohuni që fjalët që shënuat janë korrekt.</string>
-  <string name="checkbox_wordlist_password">Kam fjalëkalim</string>
+  <string name="checkbox_wordlist_passphrase">Kam fjalëkalim</string>
   <string name="wordlist_length_12">12 fjalë</string>
   <string name="wordlist_length_18">18 fjalë</string>
   <string name="wordlist_length_24">24 fjalë</string>
-  <string name="recover_seed_password_info">Zgjedhni këtë opsion vetëm kur e kuptoni çfarë do të thotë.\nNjë kopje rezervë e Mycelium kurrë nuk përmban një fjalëkalim - ky nuk është PIN-i juaj.</string>
+  <string name="recover_seed_passphrase_info">Zgjedhni këtë opsion vetëm kur e kuptoni çfarë do të thotë.\nNjë kopje rezervë e Mycelium kurrë nuk përmban një fjalëkalim - ky nuk është PIN-i juaj.</string>
   <string name="import_wordlist_questions">Ju lutem zgjedhni gjatësin e listës së fjalëve për të rikthyer dhe të tregojë nëse është i mbrojtur me fjalëkalim.</string>
   <string name="type_password_title">Shkruaj fjalëkalimin tuaj</string>
   <string name="clipboard_not_available">Memorja jovalide</string>

--- a/public/mbw/src/main/res/values-sv/strings.xml
+++ b/public/mbw/src/main/res/values-sv/strings.xml
@@ -482,11 +482,11 @@
   <string name="account_contains_one_address_info">Innehåller en adress.</string>
   <string name="verify_backup_ok_message">Verifiering av säkerhetskopian lyckades.</string>
   <string name="wordlist_import_invalid_checksum">Checksumman för din lista av ord är ogiltig, säkerställ att du har matat in alla ord korrekt.</string>
-  <string name="checkbox_wordlist_password">Jag har ett lösenord</string>
+  <string name="checkbox_wordlist_passphrase">Jag har ett lösenord</string>
   <string name="wordlist_length_12">12 ord</string>
   <string name="wordlist_length_18">18 ord</string>
   <string name="wordlist_length_24">24 ord</string>
-  <string name="recover_seed_password_info">Välj endast detta alternativ om du förstår innebörden.\nEn normal säkerhetskopia av Mycelium innehåller aldrig ett lösenord - detta är inte din PIN-kod.</string>
+  <string name="recover_seed_passphrase_info">Välj endast detta alternativ om du förstår innebörden.\nEn normal säkerhetskopia av Mycelium innehåller aldrig ett lösenord - detta är inte din PIN-kod.</string>
   <string name="import_wordlist_questions">Välj längden på listan av ord att återskapa och indikera huruvida den är skyddad av ett lösenord.</string>
   <string name="type_password_title">Ange ditt lösenord</string>
   <string name="clipboard_not_available">Urklipp är inte giltig</string>

--- a/public/mbw/src/main/res/values-zh-rTW/strings.xml
+++ b/public/mbw/src/main/res/values-zh-rTW/strings.xml
@@ -454,7 +454,7 @@
   <string name="account_contains_one_key_info">包含一個私鑰。</string>
   <string name="verify_backup_ok_message">備份驗證成功。</string>
   <string name="wordlist_import_invalid_checksum">單詞列表校驗碼無效，請確保您正確地輸入了所有單詞。</string>
-  <string name="checkbox_wordlist_password">我有一個密碼</string>
+  <string name="checkbox_wordlist_passphrase">我有一個密碼</string>
   <string name="wordlist_length_12">12 個單詞</string>
   <string name="wordlist_length_18">18 個單詞</string>
   <string name="wordlist_length_24">24 個單詞</string>

--- a/public/mbw/src/main/res/values-zh/strings.xml
+++ b/public/mbw/src/main/res/values-zh/strings.xml
@@ -456,7 +456,7 @@
   <string name="account_contains_one_key_info">包含一个私钥。</string>
   <string name="verify_backup_ok_message">备份验证成功。</string>
   <string name="wordlist_import_invalid_checksum">单词列表校验码无效，请确保您正确地输入了所有单词。</string>
-  <string name="checkbox_wordlist_password">我有一个密码</string>
+  <string name="checkbox_wordlist_passphrase">我有一个密码</string>
   <string name="wordlist_length_12">12 个字</string>
   <string name="wordlist_length_18">18 个字</string>
   <string name="wordlist_length_24">24 个单词</string>

--- a/public/mbw/src/main/res/values/strings.xml
+++ b/public/mbw/src/main/res/values/strings.xml
@@ -504,11 +504,11 @@
     <string name="account_contains_one_address_info">Contains one address.</string>
     <string name="verify_backup_ok_message">The backup was successfully verified.</string>
     <string name="wordlist_import_invalid_checksum">The checksum of your word list is invalid, please make sure you entered all words correctly.</string>
-    <string name="checkbox_wordlist_password">I have a password</string>
+    <string name="checkbox_wordlist_passphrase">I have a passphrase</string>
     <string name="wordlist_length_12">12 words</string>
     <string name="wordlist_length_18">18 words</string>
     <string name="wordlist_length_24">24 words</string>
-    <string name="recover_seed_password_info">Only select this option if you understand what it means.\nA normal Mycelium backup never includes a password - this is not your PIN.</string>
+    <string name="recover_seed_passphrase_info">Only select this option if you understand what it means.\nA normal Mycelium backup never includes a passphrase - this is not your PIN.</string>
     <string name="import_wordlist_questions">Please select the length of the word list to restore and indicate whether it is protected by a password.</string>
     <string name="type_password_title">Enter Your Password</string>
     <string name="clipboard_not_available">Clipboard not valid</string>


### PR DESCRIPTION
BIP39 uses the word passphrase to encourage using more complex passphrases than just a simple word. It's good to use this term, so people coming from different software (which uses the correct term) would not be confused.