### PR TITLE
Improved french translation

### DIFF
--- a/public/mbw/src/main/res/values-fr/strings.xml
+++ b/public/mbw/src/main/res/values-fr/strings.xml
@@ -75,7 +75,7 @@
   <string name="date">Date</string>
   <string name="inputs">Entrées</string>
   <string name="outputs">Sorties</string>
-  <string name="confirmed_in_block">En bloc #%1$d</string>
+  <string name="confirmed_in_block">Au bloc #%1$d</string>
   <string name="no">Non</string>
   <string name="yes">Oui</string>
   <string name="pref_category_pin">Paramètres de code d\'accès</string>

--- a/public/mbw/src/main/res/values-fr/strings.xml
+++ b/public/mbw/src/main/res/values-fr/strings.xml
@@ -828,7 +828,7 @@
   <string name="coinapult_verify_mail_error">Une erreur s\'est produite lors de la vérification votre adresse e-mail. Veuillez vérifier que vous avez copié entièrement le lien de vérification.</string>
   <string name="coinapult_unable_to_create_account">Impossible de créer le compte Coinapult</string>
   <string name="coinapult_failed_to_broadcast">La diffusion de la transaction Coinapult a échoué</string>
-  <string name="coinapult_add_locks_account">Ajouter un compte barré Coinapult</string>
+  <string name="coinapult_add_locks_account">Ajouter un compte verrouillé Coinapult</string>
   <string name="coinapult_tos_link">Ouvrir les conditions générales de Coinapult</string>
   <string name="coinapult_tos_question">Pour créer un compte Coinapult, vous devez accepter les conditions générales</string>
   <string name="coinapult_mail_question">Voulez-vous fournir votre adresse e-mail ?</string>


### PR DESCRIPTION
"Confirmée au bloc xx" sounds more natural in french than "Confirmée en bloc xx"

Also replaced "compte barré Coinapult" by "compte verrouillé Coinapult" ("barré" means "crossed out" which is a little bit misleading).