### PR TITLE
Fix "Hangs at start-up logo" #336

### DIFF
--- a/mbw/src/main/java/com/mycelium/wallet/activity/StartupActivity.java
+++ b/mbw/src/main/java/com/mycelium/wallet/activity/StartupActivity.java
@@ -116,6 +116,17 @@ public class StartupActivity extends Activity {
    }
 
    @Override
+   protected void onRestart() {
+      // This auto-opens pin dialog when going back to activity
+      if (_mbwManager != null && _pinDialog != null) {
+         if (_mbwManager.isUnlockPinRequired() && !_pinDialog.isShowing()) {
+            delayedFinish.run();
+         }
+      }
+      super.onRestart();
+   }
+
+   @Override
    protected void onDestroy() {
       if (_alertDialog != null && _alertDialog.isShowing()) {
          _alertDialog.dismiss();


### PR DESCRIPTION
I added simple check in `onRestart()`, to show pin dialog when `StartupActivity` get's paused into background.

This commit fixes https://github.com/mycelium-com/wallet/issues/336